### PR TITLE
Apply builder for creating commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 *.swp
+*.py
+*.yaml
 .idea
 .vscode
 build/
+manifest/

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,37 @@
-export CGO_ENABLED=0
+CGO_ENABLED?=0
 
+# echo current target name
 define echo_target
 	@echo ">>> $@"
 endef
 
+# for make run with arguments
 ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
   $(eval $(RUN_ARGS):;@:)
 endif
 
+.PHONY: fmt
 fmt:
 	@$(echo_target)
 	@go fmt ./...
 
+.PHONY: test
+test:
+	@$(echo_target)
+	@go test ./...
+
+.PHONY: build
 build: fmt
 	@$(echo_target)
-	@go build -o build/klocust ./cmd/main.go
-	@ls -lh build/klocust
+	@go build -ldflags "-w -s" -o build/klocust ./cmd/main.go
 
+.PHONY: clean
 clean:
 	@$(echo_target)
 	@rm -rf build/klocust
 
+.PHONY: run
 run:
 	@$(echo_target)
 	@go run ./cmd/main.go $(RUN_ARGS)
-
-.PHONY: fmt build clean run

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # klocust
 A command-line tool for managing [Locust](https://locust.io/) distributed load testing on [Kubernetes](https://kubernetes.io/)
+
+# Install klocust
+
+# klocust list
+```bash
+$ klocust list
+
+>>> 1 locust deployments in loadtest namespace. (PREFIX: locust-master-)
++-------+---------------------+-------+------------+-----------+------+
+| NAME  | DEPLOYMENT          | READY | UP-TO-DATE | AVAILABLE | AGE  |
++-------+---------------------+-------+------------+-----------+------+
+| hello | locust-master-hello | 1/1   | 1          | 1         | 9m5s |
++-------+---------------------+-------+------------+-----------+------+
+```
+
+# build klocust binary
+```bash
+$ make build
+```

--- a/cmd/builder/builder.go
+++ b/cmd/builder/builder.go
@@ -1,0 +1,103 @@
+// Builder from https://github.com/GoogleContainerTools/skaffold
+package builder
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"io"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Builder is used to build cobra commands.
+type Builder interface {
+	WithDescription(description string) Builder
+	WithLongDescription(long string) Builder
+	WithExample(comment, command string) Builder
+	WithFlags(adder func(*pflag.FlagSet)) Builder
+	WithCommonFlags() Builder
+	Hidden() Builder
+	ExactArgs(argCount int, action func(context.Context, io.Writer, *cobra.Command, []string) error) *cobra.Command
+	NoArgs(action func(context.Context, io.Writer) error) *cobra.Command
+}
+
+type builder struct {
+	cmd cobra.Command
+}
+
+// NewCmd creates a new command builder.
+func NewCmd(use string) *builder {
+	return &builder{
+		cmd: cobra.Command{
+			Use: use,
+		},
+	}
+}
+
+func (b *builder) WithDescription(description string) Builder {
+	b.cmd.Short = description
+	return b
+}
+
+func (b *builder) WithLongDescription(long string) Builder {
+	b.cmd.Long = long
+	return b
+}
+
+func (b *builder) WithExample(comment, command string) Builder {
+	if b.cmd.Example != "" {
+		b.cmd.Example += "\n"
+	}
+	b.cmd.Example += fmt.Sprintf("  # %s\n  klocust %s\n", comment, command)
+	return b
+}
+
+func (b *builder) WithCommonFlags() Builder {
+	AddFlags(&b.cmd)
+	return b
+}
+
+func (b *builder) WithFlags(adder func(*pflag.FlagSet)) Builder {
+	adder(b.cmd.Flags())
+	return b
+}
+
+func (b *builder) Hidden() Builder {
+	b.cmd.Hidden = true
+	return b
+}
+
+func (b *builder) SetAliases(alias []string) Builder {
+	b.cmd.Aliases = alias
+	return b
+}
+
+func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer, *cobra.Command, []string) error) *cobra.Command {
+	b.cmd.Args = cobra.ExactArgs(argCount)
+	b.cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout(), cmd, args))
+	}
+	return &b.cmd
+}
+
+func (b *builder) NoArgs(action func(context.Context, io.Writer) error) *cobra.Command {
+	b.cmd.Args = cobra.NoArgs
+	b.cmd.RunE = func(*cobra.Command, []string) error {
+		return handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout()))
+	}
+	return &b.cmd
+}
+
+func handleWellKnownErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.IsUnauthorized(err) {
+		fmt.Println("Please check your kubeconfig:", err)
+		return nil
+	}
+
+	return err
+}

--- a/cmd/builder/flag.go
+++ b/cmd/builder/flag.go
@@ -1,0 +1,107 @@
+// Flag from https://github.com/GoogleContainerTools/skaffold
+package builder
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type Flag struct {
+	Name               string
+	Shorthand          string
+	Usage              string
+	Value              interface{}
+	DefValue           interface{}
+	DefValuePerCommand map[string]interface{}
+	FlagAddMethod      string
+	DefinedOn          []string
+	Hidden             bool
+
+	pflag *pflag.Flag
+}
+
+var flagRegistry = []Flag{}
+
+func (fl *Flag) flag() *pflag.Flag {
+	if fl.pflag != nil {
+		return fl.pflag
+	}
+
+	inputs := []interface{}{fl.Value, fl.Name}
+	if fl.FlagAddMethod != "Var" {
+		inputs = append(inputs, fl.DefValue)
+	}
+	inputs = append(inputs, fl.Usage)
+
+	fs := pflag.NewFlagSet(fl.Name, pflag.ContinueOnError)
+
+	reflect.ValueOf(fs).MethodByName(fl.FlagAddMethod).Call(reflectValueOf(inputs))
+	f := fs.Lookup(fl.Name)
+	f.Shorthand = fl.Shorthand
+	f.Hidden = fl.Hidden
+
+	fl.pflag = f
+	return f
+}
+
+func reflectValueOf(values []interface{}) []reflect.Value {
+	var results []reflect.Value
+	for _, v := range values {
+		results = append(results, reflect.ValueOf(v))
+	}
+	return results
+}
+
+// AddFlags adds to the command the common flags that are annotated with the command name.
+func AddFlags(cmd *cobra.Command) {
+	var flagsForCommand []*Flag
+
+	for i := range flagRegistry {
+		fl := &flagRegistry[i]
+		if !hasCmdAnnotation(cmd.Use, fl.DefinedOn) {
+			continue
+		}
+
+		cmd.Flags().AddFlag(fl.flag())
+
+		flagsForCommand = append(flagsForCommand, fl)
+	}
+
+	// Apply command-specific default values to flags.
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// Update default values.
+		for _, fl := range flagsForCommand {
+			if defValue, present := fl.DefValuePerCommand[cmd.Use]; present {
+				if flag := cmd.Flag(fl.Name); !flag.Changed {
+					flag.Value.Set(fmt.Sprintf("%v", defValue))
+				}
+			}
+		}
+
+		// Since PersistentPreRunE replaces the parent's PersistentPreRunE,
+		// make sure we call it, if it is set.
+		if parent := cmd.Parent(); parent != nil {
+			if preRun := parent.PersistentPreRunE; preRun != nil {
+				if err := preRun(cmd, args); err != nil {
+					return err
+				}
+			} else if preRun := parent.PersistentPreRun; preRun != nil {
+				preRun(cmd, args)
+			}
+		}
+
+		return nil
+	}
+}
+
+func hasCmdAnnotation(cmdName string, annotations []string) bool {
+	for _, a := range annotations {
+		if cmdName == a || a == "all" {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/klocust/completion.go
+++ b/cmd/klocust/completion.go
@@ -1,9 +1,10 @@
+// completion from https://github.com/GoogleContainerTools/skaffold
 package klocust
 
 import (
-	"fmt"
+	"context"
+	"github.com/DevopsArtFactory/klocust/cmd/builder"
 	"io"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,34 +31,21 @@ Additionally, you may want to output the completion to a file and source in your
 	zshCompdef = "\ncompdef _klocust klocust\n"
 )
 
-func completion(cmd *cobra.Command, args []string) {
+func completion(_ context.Context, _ io.Writer, cmd *cobra.Command, args []string) error {
 	switch args[0] {
 	case "bash":
-		if err := findRootCmd(cmd).GenBashCompletion(os.Stdout); err != nil {
-			log.Fatal(err)
-		}
+		return findRootCmd(cmd).GenBashCompletion(os.Stdout)
 	case "zsh":
-		if err := runCompletionZsh(cmd, os.Stdout); err != nil {
-			log.Fatal(err)
-		}
+		return runCompletionZsh(cmd, os.Stdout)
 	}
+	return nil
 }
 
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion() *cobra.Command {
-	return &cobra.Command{
-		Use: "completion (bash|zsh)",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("requires 1 arg, found %d", len(args))
-			}
-			return cobra.OnlyValidArgs(cmd, args)
-		},
-		ValidArgs: []string{"bash", "zsh"},
-		Short:     "Output shell completion for the given shell (bash or zsh)",
-		Long:      longDescription,
-		Run:       completion,
-	}
+	return builder.NewCmd("completion").
+		WithDescription("Output shell completion for the given shell (bash or zsh)").
+		ExactArgs(1, completion)
 }
 
 func runCompletionZsh(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/klocust/list.go
+++ b/cmd/klocust/list.go
@@ -1,39 +1,26 @@
 package klocust
 
 import (
-	"fmt"
+	"context"
+	"github.com/DevopsArtFactory/klocust/cmd/builder"
 	"github.com/DevopsArtFactory/klocust/internal/klocust"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"log"
+	"github.com/spf13/pflag"
+	"io"
 )
 
-func list(cmd *cobra.Command, args []string) {
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		log.Fatal(err)
-	}
+var (
+	namespace string
+)
 
-	if err := klocust.PrintLocustDeployments(namespace); err != nil {
-		if errors.IsUnauthorized(err) {
-			fmt.Println("Check your kubeconfig: ", err)
-		}
-		log.Fatal(err)
-	}
+func list(_ context.Context, _ io.Writer) error {
+	return klocust.PrintLocustDeployments(namespace)
 }
 
 func NewCmdList() *cobra.Command {
-	newCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Args: func(cmd *cobra.Command, args []string) error {
-			return cobra.OnlyValidArgs(cmd, args)
-		},
-		ValidArgs: []string{"list", "ls"},
-		Short:     "Print all of Locust clusters",
-		Run:       list,
-	}
-
-	newCmd.Flags().StringP("namespace", "n", "", "kubernetes namespace name")
-	return newCmd
+	return builder.NewCmd("list").
+		WithDescription("Print all of Locust clusters").
+		WithFlags(func(f *pflag.FlagSet) {
+			f.StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace")
+		}).NoArgs(list)
 }

--- a/cmd/klocust/root.go
+++ b/cmd/klocust/root.go
@@ -15,8 +15,7 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "klocust",
-	Short: "A command-line tool for managing Locust distributed load testing on Kubernetes",
-	Long:  `A command-line tool for managing Locust distributed load testing on Kubernetes`,
+	Short: "klocust - A command-line tool for managing Locust distributed load testing on Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cmd.Help(); err != nil {
 			log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	k8s.io/api v0.19.2

--- a/internal/klocust/constant.go
+++ b/internal/klocust/constant.go
@@ -1,0 +1,4 @@
+package klocust
+
+const LocustMasterDeploymentPrefix = "locust-master-"
+

--- a/internal/klocust/list.go
+++ b/internal/klocust/list.go
@@ -11,8 +11,6 @@ import (
 	"time"
 )
 
-const LocustMasterDeploymentPrefix = "locust-master-"
-
 func getLocustDeployments(namespace string) ([]v1.Deployment, error) {
 	deployments, err := kube.GetDeployments(namespace)
 	if err != nil {
@@ -51,17 +49,17 @@ func PrintLocustDeployments(namespace string) error {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"DEPLOYMENT", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"})
-	table.SetHeaderAlignment(tablewriter.ALIGN_RIGHT)
-	table.SetAlignment(tablewriter.ALIGN_RIGHT)
+	table.SetHeader([]string{"NAME", "DEPLOYMENT", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 
 	for _, d := range locustDeployments {
 		name := d.Name[len(LocustMasterDeploymentPrefix):]
 		age := time.Since(d.CreationTimestamp.Time).Round(time.Second)
 
 		table.Append([]string{
-			d.Name,
 			name,
+			d.Name,
 			strconv.Itoa(int(d.Status.ReadyReplicas)) + "/" + strconv.Itoa(int(d.Status.Replicas)),
 			strconv.Itoa(int(d.Status.UpdatedReplicas)),
 			strconv.Itoa(int(d.Status.AvailableReplicas)),

--- a/internal/kube/deployment.go
+++ b/internal/kube/deployment.go
@@ -8,6 +8,20 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+func GetDeployment(namespace string, name string) (*v1.Deployment, error) {
+	client, err := newClient()
+	if err != nil {
+		return nil, err
+	}
+
+	deployment, err := client.AppsV1().Deployments(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return deployment, nil
+}
+
 func GetDeployments(namespace string) (*v1.DeploymentList, error) {
 	client, err := newClient()
 	if err != nil {


### PR DESCRIPTION
* Apply builder for creating CLI commands.
   It would be make more easier when creating and using commands.
 * builder reference: https://github.com/GoogleContainerTools/skaffold/blob/master/cmd/skaffold/app/cmd/commands.go