### PR TITLE
Download default templates if it does not exists before applying

### DIFF
--- a/internal/klocust/apply.go
+++ b/internal/klocust/apply.go
@@ -108,6 +108,12 @@ func ApplyLocust(namespace string, locustName string) error {
 		return err
 	}
 
+	if !util.IsDirExists(locustHomeDefaultTemplatesDir) {
+		if err := downloadDefaultTemplates(); err != nil {
+			return err
+		}
+	}
+
 	if isExist {
 		klog.Infof("> Start applying locust cluster: %s\n", locustName)
 	} else {


### PR DESCRIPTION
* Download default templates to {USER HOME}/.klocust if it does not exists before applying.
* If user download klocust files from co-worker first. He|She doesn't have default templates in {USER_HOME}/.klocust/_default_templates. 
   So download default templates if it does not exist before applying too.