### PR TITLE
change docker image as dynamic variable

### DIFF
--- a/pkg/klocust/_default_templates/templates/main-deployment.yaml
+++ b/pkg/klocust/_default_templates/templates/main-deployment.yaml
@@ -36,7 +36,7 @@ spec:
 {{- end }}
       containers:
         - name: locust-main
-          image: locustio/locust:latest
+          image: {{ .Main.Image }}
           args: ["-f", "/mnt/locust/{{ .LocustName }}-locustfile.py", "--master"]
           resources:
             requests:

--- a/pkg/klocust/_default_templates/templates/worker-deployment.yaml
+++ b/pkg/klocust/_default_templates/templates/worker-deployment.yaml
@@ -41,7 +41,7 @@ spec:
 {{- end }}
       containers:
         - name: locust-worker
-          image: locustio/locust:latest
+          image: {{ .Worker.Image }}
           resources:
             requests:
               cpu: {{ .Worker.Requests.CPU }}

--- a/pkg/klocust/apply.go
+++ b/pkg/klocust/apply.go
@@ -44,6 +44,8 @@ func renderProjectTemplates(locustName string) ([]*bytes.Buffer, error) {
 		return nil, err
 	}
 
+	SetDefaultToValues(&values)
+
 	for _, filename := range locustFilenames {
 		if !strings.HasSuffix(filename, ".yaml") ||
 			strings.HasSuffix(filename, valuesFilename) {
@@ -116,4 +118,15 @@ func ApplyLocust(out io.Writer, namespace string, locustName string) error {
 		return err
 	}
 	return nil
+}
+
+// SetDefaultToValues sets default values if user does not specify.
+func SetDefaultToValues(values *schemas.LocustValues) {
+	if values.Worker.Image == "" {
+		values.Worker.Image = DefaultDockerImage
+	}
+
+	if values.Main.Image == "" {
+		values.Main.Image = DefaultDockerImage
+	}
 }

--- a/pkg/klocust/apply_test.go
+++ b/pkg/klocust/apply_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The klocust Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klocust
+
+import (
+	"testing"
+
+	"github.com/DevopsArtFactory/klocust/pkg/schemas"
+)
+
+func Test_SetDefault(t *testing.T) {
+	var values schemas.LocustValues
+
+	SetDefaultToValues(&values)
+	if values.Worker.Image != DefaultDockerImage {
+		t.Errorf("default value should be applied for worker node image")
+	}
+
+	if values.Main.Image != DefaultDockerImage {
+		t.Errorf("default value should be applied for main node image")
+	}
+
+	testImage := "test:latest"
+	values.Worker.Image = testImage
+	values.Main.Image = testImage
+	SetDefaultToValues(&values)
+	if values.Worker.Image != testImage {
+		t.Errorf("default value should not be applied for worker node image")
+	}
+
+	if values.Main.Image != testImage {
+		t.Errorf("default value should not be applied for main node image")
+	}
+}

--- a/pkg/klocust/constant.go
+++ b/pkg/klocust/constant.go
@@ -53,6 +53,8 @@ const (
 
 	// DefaultLogLevel is the default global verbosity
 	DefaultLogLevel = logrus.WarnLevel
+
+	DefaultDockerImage = "locustio/locust:latest"
 )
 
 func getEmbedTemplatePath(filename string) string {

--- a/pkg/schemas/locust_values.go
+++ b/pkg/schemas/locust_values.go
@@ -32,8 +32,11 @@ type LocustValues struct {
 		LocustFileContents string `yaml:"locustFileContents"`
 	}
 
-	// Loucst Main Node
+	// Locust Main Node
 	Main struct {
+		// Docker image of Main Node
+		Image string `yaml:"image"`
+
 		// Resource Requests of Main Node
 		Requests struct {
 			// Request of Main Node CPU
@@ -68,6 +71,9 @@ type LocustValues struct {
 
 	// Locust Worker Node
 	Worker struct {
+		// Docker image of worker node
+		Image string `yaml:"image"`
+
 		// Count of Worker Node
 		Count int `yaml:"count"`
 


### PR DESCRIPTION
Change docker image of deployments as dynamic variables. User can set custom image in the `yaml` file. 
This is required because if klocust uses only `locustio/locust:latest` image, then when user wants to run lots of containers at the same time, it will occur limit error.

