### PR TITLE
Fix nginx ingress templates

### DIFF
--- a/pkg/klocust/_default_templates/templates/main-ingress.yaml
+++ b/pkg/klocust/_default_templates/templates/main-ingress.yaml
@@ -21,7 +21,6 @@ metadata:
       nginx.org/proxy-connect-timeout: "30s"
       nginx.org/proxy-read-timeout: "20s"
       nginx.org/client-max-body-size: "4m"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}
 {{- with .Ingress.Annotations }}
 {{ toYaml . | indent 6 }}
@@ -36,7 +35,7 @@ spec:
     - host: {{ .Ingress.Host }}
       http:
         paths:
-          - path: /*
+          - path: /
             backend:
               serviceName: locust-main-{{ .LocustName }}
               servicePort: {{ .Service.Port }}


### PR DESCRIPTION
* nginx ingress not working with previous templates.
* so I've changed next parts of main-ingress.yaml template file.
  * delete `nginx.ingress.kubernetes.io/force-ssl-redirect: true` - user
    can be overwrite this using annotation if it need.
  * change default path `/*` to `*`.
    `/*` made some problem with ingress conversion (v1beta to v1)