### PR TITLE
update kubernetes ingress api version and template

### DIFF
--- a/pkg/klocust/_default_templates/templates/main-ingress.yaml
+++ b/pkg/klocust/_default_templates/templates/main-ingress.yaml
@@ -1,12 +1,11 @@
 {{- if .Ingress.Class -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ .Namespace }}
   name: locust-main-{{ .LocustName }}
   annotations:
     {{- if eq .Ingress.Class "alb" }}
-      kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/scheme: {{ .Ingress.ALB.Scheme }}
       alb.ingress.kubernetes.io/security-groups: {{ .Ingress.ALB.SecurityGroups }}
       {{- if .Ingress.ALB.CertificateARN }}
@@ -31,12 +30,18 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if eq .Ingress.Class "alb" }}
+  ingressClassName: alb
+  {{- end }}
   rules:
     - host: {{ .Ingress.Host }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: locust-main-{{ .LocustName }}
-              servicePort: {{ .Service.Port }}
+              service:
+                name: locust-main-{{ .LocustName }}
+                port:
+                  number: {{ .Service.Port }}
 {{- end -}}

--- a/pkg/klocust/apply.go
+++ b/pkg/klocust/apply.go
@@ -70,9 +70,9 @@ func renderProjectTemplates(locustName string) ([]*bytes.Buffer, error) {
 	return renderedBufList, nil
 }
 
-func applyYamlFiles(out io.Writer, namespace string, renderedBufList []*bytes.Buffer) error {
+func applyYamlFiles(out io.Writer, renderedBufList []*bytes.Buffer) error {
 	for _, renderedBuf := range renderedBufList {
-		obj, err := handler.Apply(namespace, renderedBuf)
+		obj, err := handler.Apply(renderedBuf)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func ApplyLocust(out io.Writer, namespace string, locustName string) error {
 		return err
 	}
 
-	if err := applyYamlFiles(out, namespace, renderedBufList); err != nil {
+	if err := applyYamlFiles(out, renderedBufList); err != nil {
 		return err
 	}
 

--- a/pkg/klocust/delete.go
+++ b/pkg/klocust/delete.go
@@ -29,9 +29,9 @@ import (
 	"github.com/DevopsArtFactory/klocust/pkg/printer"
 )
 
-func deleteYamlFiles(out io.Writer, namespace string, renderedBufList []*bytes.Buffer) error {
+func deleteYamlFiles(out io.Writer, renderedBufList []*bytes.Buffer) error {
 	for _, renderedBuf := range renderedBufList {
-		obj, err := handler.Delete(namespace, renderedBuf)
+		obj, err := handler.Delete(renderedBuf)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func DeleteLocust(out io.Writer, namespace string, locustName string) error {
 		return err
 	}
 
-	if err := deleteYamlFiles(out, namespace, renderedBufList); err != nil {
+	if err := deleteYamlFiles(out, renderedBufList); err != nil {
 		return err
 	}
 

--- a/pkg/kube/handler/apply.go
+++ b/pkg/kube/handler/apply.go
@@ -60,13 +60,13 @@ func applyService(ctx context.Context, client kubernetes.Interface, obj *unstruc
 }
 
 func applyIngress(ctx context.Context, client kubernetes.Interface, obj *unstructured.Unstructured, data []byte) error {
-	if _, err := client.NetworkingV1beta1().Ingresses(obj.GetNamespace()).Patch(
+	if _, err := client.NetworkingV1().Ingresses(obj.GetNamespace()).Patch(
 		ctx, obj.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: "klocust"}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func Apply(namespace string, renderedBuf *bytes.Buffer) (*unstructured.Unstructured, error) {
+func Apply(renderedBuf *bytes.Buffer) (*unstructured.Unstructured, error) {
 	return handleObjFromYamlFile(applyFuncs, renderedBuf)
 }

--- a/pkg/kube/handler/delete.go
+++ b/pkg/kube/handler/delete.go
@@ -50,10 +50,10 @@ func deleteService(ctx context.Context, client kubernetes.Interface, obj *unstru
 }
 
 func deleteIngress(ctx context.Context, client kubernetes.Interface, obj *unstructured.Unstructured, _ []byte) error {
-	return client.NetworkingV1beta1().Ingresses(obj.GetNamespace()).Delete(
+	return client.NetworkingV1().Ingresses(obj.GetNamespace()).Delete(
 		ctx, obj.GetName(), metav1.DeleteOptions{})
 }
 
-func Delete(namespace string, renderedBuf *bytes.Buffer) (*unstructured.Unstructured, error) {
+func Delete(renderedBuf *bytes.Buffer) (*unstructured.Unstructured, error) {
 	return handleObjFromYamlFile(deleteFuncs, renderedBuf)
 }


### PR DESCRIPTION
- ingress api version이 v1beta1인 부분을 v1으로 변경합니다.(1.19 이상에서는 v1 api)
- ingress template을 수정합니다.
- 코드의 사용하지 않는 namespace 변수를 제거합니다.