### PR TITLE
ci: release artifacts to S3 on tag

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,36 @@
+name: Release On Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      AWS_DEFAULT_REGION: ap-northeast-2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          cache: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gitaction
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Build and upload artifacts to S3
+        run: make release


### PR DESCRIPTION
## Summary
- add tag-triggered GitHub Actions workflow: `.github/workflows/release-on-tag.yml`
- trigger on tag push (`v*`) and manual dispatch
- configure AWS credentials via OIDC (`aws-actions/configure-aws-credentials@v4`)
- run `make release` to build artifacts and upload to S3

## Required repository settings
- Secret: `AWS_ACCOUNT_ID`
- Variable: `AWS_DEFAULT_REGION`
- IAM role: `arn:aws:iam::<AWS_ACCOUNT_ID>:role/gitaction` with GitHub OIDC trust and S3 upload permissions
